### PR TITLE
Fixed LRU cache and added tests

### DIFF
--- a/dstruct/lru.go
+++ b/dstruct/lru.go
@@ -1,24 +1,35 @@
 package dstruct
 
+type lruEntry[K, V any] struct {
+	epoch epoch
+	key   K
+	data  V
+}
+
+type index int
+type epoch uint64
+
 // LruCache is a implements a Least Recently Used cache.
 // It acts as a dictionary of keys and values, with a maximum number of
 // entries. When this maximum is surpassed, the least recently used item
 // is dropped.
 type LruCache[K comparable, V any] struct {
-	byAge    Heap[*lruEntry[K, V]] // Heap to quickly acces items by age.
-	byKey    map[K]*lruEntry[K, V] // Map to quickly access to items by key.
-	data     []lruEntry[K, V]      // Raw data.
-	capacity int                   // Max amount of items.
-	epoch    lruEpoch              // A timestamp. Updated every read and write.
+	byAge    Heap[index]      // Heap to quickly acces items by age.
+	byKey    map[K]index      // Map to quickly access to items by key.
+	data     []lruEntry[K, V] // Raw data.
+	capacity int              // Max amount of items.
+	epoch    epoch            // A timestamp. Updated every read and write.
 }
 
 // NewLRU creates new lru cache with the specified capacity,
 // measured in number of key-value paires stored.
 func NewLRU[K comparable, V any](cap int) *LruCache[K, V] {
+	alloc := make([]lruEntry[K, V], cap)
+
 	return &LruCache[K, V]{
-		byKey:    map[K]*lruEntry[K, V]{},
-		byAge:    NewHeap(func(x, y *lruEntry[K, V]) bool { return x.epoch < y.epoch }),
-		data:     make([]lruEntry[K, V], cap),
+		byKey:    map[K]index{},
+		byAge:    NewHeap(func(x, y index) bool { return alloc[x].epoch < alloc[y].epoch }),
+		data:     alloc,
 		capacity: cap,
 		epoch:    1,
 	}
@@ -33,44 +44,52 @@ func (lru LruCache[K, V]) Len() int {
 // is registered. If so, the value is returned and its
 // epoch updated.
 func (lru *LruCache[K, V]) Get(key K) (v V, ok bool) {
-	entry, ok := lru.byKey[key]
+	entry, ok := lru.get(key)
 	if !ok {
 		return v, false
 	}
+	return entry.data, true
+}
+
+// get accesses an item in the cache and updates its epoch.
+func (lru *LruCache[K, V]) get(k K) (*lruEntry[K, V], bool) {
+	idx, ok := lru.byKey[k]
+	entry := &lru.data[idx]
+	if !ok {
+		return nil, false
+	}
 	lru.epoch++
 	entry.epoch = lru.epoch
-	return entry.data, true
+	lru.byAge.Fix(int(idx))
+
+	return entry, true
 }
 
 // Set checks if an entry was in the cache. If it was,
 // it updates its epoch. Otherwise, it adds it anew.
 func (lru LruCache[K, V]) Set(k K, v V) {
 	lru.epoch++
-	entry, ok := lru.byKey[k]
+	entry, ok := lru.get(k)
 	if ok {
-		entry.epoch = lru.epoch
+		entry.data = v
 		return
 	}
-	var ptr *lruEntry[K, V]
+
+	var idx index
 	if lru.Len() >= lru.capacity {
-		ptr = lru.byAge.Pop()
-		delete(lru.byKey, ptr.key)
+		idx = lru.byAge.Pop()
+		delete(lru.byKey, lru.data[idx].key)
 	} else {
-		ptr = &lru.data[lru.Len()]
+		idx = index(lru.Len())
+	}
+	ptr := &lru.data[idx]
+
+	*ptr = lruEntry[K, V]{
+		epoch: lru.epoch,
+		key:   k,
+		data:  v,
 	}
 
-	ptr.epoch = lru.epoch
-	ptr.key = k
-	ptr.data = v
-
-	lru.byKey[k] = ptr
-	lru.byAge.Push(ptr)
-}
-
-type lruEpoch uint64
-
-type lruEntry[K, V any] struct {
-	epoch lruEpoch
-	key   K
-	data  V
+	lru.byKey[k] = idx
+	lru.byAge.Push(idx)
 }

--- a/dstruct/lru_test.go
+++ b/dstruct/lru_test.go
@@ -1,0 +1,81 @@
+package dstruct_test
+
+import (
+	"testing"
+
+	"github.com/EduardGomezEscandell/algo/dstruct"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLRU(t *testing.T) {
+	lru := dstruct.NewLRU[uint, string](5)
+	lru.Set(1, "Numero uno")
+
+	v, ok := lru.Get(1)
+	require.True(t, ok, "Failed to get value that should have been in cache")
+	require.Equal(t, v, "Numero uno", "Retrieved wrong value from cache")
+
+	lru.Set(1, "one")
+	lru.Set(2, "two")
+	lru.Set(3, "three")
+
+	v, ok = lru.Get(1)
+	require.True(t, ok, "Failed to get value that should have been in cache")
+	require.Equal(t, v, "one", "Retrieved wrong value from cache")
+
+	v, ok = lru.Get(3)
+	require.True(t, ok, "Failed to get value that should have been in cache")
+	require.Equal(t, v, "three", "Retrieved wrong value from cache")
+
+	_, ok = lru.Get(700)
+	require.False(t, ok, "Got value that should have not been in cache")
+
+	v, ok = lru.Get(2)
+	require.True(t, ok, "Failed to get value that should have been in cache")
+	require.Equal(t, v, "two", "Retrieved wrong value from cache")
+
+	// We ensure that {2, "two"} and {3, "three"} are removed from cache when newer entries are added.
+	// We also ensure that the newer entries are properly written in.
+	lru.Get(1) // Refreshed
+	lru.Set(100, "one hundred")
+	lru.Set(200, "two hundred")
+	lru.Set(300, "three hundred")
+	lru.Set(400, "four hundred")
+
+	v, ok = lru.Get(1)
+	require.True(t, ok, "Failed to get value that should have been in cache")
+	require.Equal(t, v, "one", "Retrieved wrong value from cache")
+
+	_, ok = lru.Get(2)
+	require.False(t, ok, "Got value that have been removed from cache")
+
+	_, ok = lru.Get(3)
+	require.False(t, ok, "Got value that have been removed from cache")
+
+	v, ok = lru.Get(100)
+	require.True(t, ok, "Failed to get value that should have been in cache")
+	require.Equal(t, v, "one hundred", "Retrieved wrong value from cache")
+
+	v, ok = lru.Get(200)
+	require.True(t, ok, "Failed to get value that should have been in cache")
+	require.Equal(t, v, "two hundred", "Retrieved wrong value from cache")
+
+	v, ok = lru.Get(300)
+	require.True(t, ok, "Failed to get value that should have been in cache")
+	require.Equal(t, v, "three hundred", "Retrieved wrong value from cache")
+
+	v, ok = lru.Get(400)
+	require.True(t, ok, "Failed to get value that should have been in cache")
+	require.Equal(t, v, "four hundred", "Retrieved wrong value from cache")
+
+	// We ensure that {1, "one"} has been refreshed when we last accessed it.
+	lru.Get(1) // Refreshed
+	lru.Set(1000, "one thousand")
+	lru.Set(2000, "two thousand")
+	lru.Set(3000, "three thousand")
+	lru.Set(4000, "four thousand")
+
+	v, ok = lru.Get(1)
+	require.True(t, ok, "Failed to get value that should have been in cache")
+	require.Equal(t, v, "one", "Retrieved wrong value from cache")
+}


### PR DESCRIPTION
LRU cache had two big problems:
- Age was being updated but the heap was not fixed.
- Set method did not overwrite existing entries

This is now fixed as proven by tests.